### PR TITLE
PLATUI-442: apply accessibility fix for add-to-a-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.31.0 - 2021-04-27
+
+### Fixed
+
+- Accessibility issue with hmrcAddToAList (
+  see [comment from Adam Liptrot on github issue 31 describing problem and solution](https://github.com/hmrc/design-patterns/issues/31#issuecomment-799628620))
+  . Previously JAWS list items dialog would announce action labels as well as the item identifier when describing a list
+  item. Following this change only the actual identifier for the row will be announced.
+
 ## [1.30.1] - 2021-04-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/add-to-a-list/__snapshots__/template.test.js.snap
+++ b/src/components/add-to-a-list/__snapshots__/template.test.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Add to a list should be rendered using a structure accessible for JAWS users 1`] = `
+
+<div class="hmrc-add-to-a-list__contents">
+  <dt class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
+    Director One
+  </dt>
+  <dd class="hmrc-add-to-a-list__change">
+    <a class="govuk-link"
+       href="#change-item-1"
+    >
+      <span aria-hidden="true">
+        Change
+      </span>
+      <span class="govuk-visually-hidden">
+        Change Director One
+      </span>
+    </a>
+  </dd>
+  <dd class="hmrc-add-to-a-list__remove">
+    <a class="govuk-link"
+       href="#remove-item-1"
+    >
+      <span aria-hidden="true">
+        Remove
+      </span>
+      <span class="govuk-visually-hidden">
+        Remove Director One from the list
+      </span>
+    </a>
+  </dd>
+</div>
+<div class="hmrc-add-to-a-list__contents">
+  <dt class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
+    Director Two
+  </dt>
+  <dd class="hmrc-add-to-a-list__change">
+    <a class="govuk-link"
+       href="#change-item-2"
+    >
+      <span aria-hidden="true">
+        Change
+      </span>
+      <span class="govuk-visually-hidden">
+        Change Director Two
+      </span>
+    </a>
+  </dd>
+  <dd class="hmrc-add-to-a-list__remove">
+    <a class="govuk-link"
+       href="#remove-item-2"
+    >
+      <span aria-hidden="true">
+        Remove
+      </span>
+      <span class="govuk-visually-hidden">
+        Remove Director Two from the list
+      </span>
+    </a>
+  </dd>
+</div>
+
+`;

--- a/src/components/add-to-a-list/template.njk
+++ b/src/components/add-to-a-list/template.njk
@@ -37,31 +37,31 @@
 {%- endif -%}
 </h1>
 <div class="govuk-form-group">
-  <ul class="hmrc-add-to-a-list hmrc-add-to-a-list--{{ params.itemSize | default('short') }}">
+  <dl class="hmrc-add-to-a-list hmrc-add-to-a-list--{{ params.itemSize | default('short') }}">
     {# loop through items in  the itemList #}
     {% for item in params.itemList %}
-    <li class="hmrc-add-to-a-list__contents">
-      <span class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
+    <div class="hmrc-add-to-a-list__contents">
+      <dt class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
         {{ item.name }}
-      </span>
-      <span class="hmrc-add-to-a-list__change">
+      </dt>
+      <dd class="hmrc-add-to-a-list__change">
         <a class="govuk-link" href="{{ item.changeUrl }}">
           <span aria-hidden="true">{{messages.change}}</span>
           <span class="govuk-visually-hidden">{{messages.change}} {{ item.name }}</span>
         </a>
-      </span>
-      <span class="hmrc-add-to-a-list__remove">
+      </dd>
+      <dd class="hmrc-add-to-a-list__remove">
         <a class="govuk-link" href="{{ item.removeUrl }}">
           <span aria-hidden="true">{{messages.remove}}</span>
           <span class="govuk-visually-hidden">{{messages.aria.before}} {{ item.name }} {{messages.aria.after}}</span>
         </a>
-      </span>
-    </li>
+      </dd>
+    </div>
     {% else %}
       {# empty list stuff goes here #}
     {% endfor %}
     {# end loop #}
-  </ul>
+  </dl>
 </div>
 <form method="post" action="{{ params.formAction }}">
   {{ govukRadios({

--- a/src/components/add-to-a-list/template.test.js
+++ b/src/components/add-to-a-list/template.test.js
@@ -23,6 +23,15 @@ const getTableItems = ($) => {
 };
 
 describe('Add to a list', () => {
+  it('should be rendered using a structure accessible for JAWS users', () => {
+    // See Adam Liptrot's comment on
+    // https://github.com/hmrc/design-patterns/issues/31#issuecomment-799628620
+
+    const $ = render('add-to-a-list', examples['multiple-specific-items']);
+
+    expect($('.hmrc-add-to-a-list').first().html()).toMatchSnapshot();
+  });
+
   describe('by default', () => {
     const $ = render('add-to-a-list', examples.default);
     const $heading = $('h1');


### PR DESCRIPTION
Adam Liptrot found that when interacting with the list using JAWS list
items dialog that the subject of each list item AND the labels for the
actions available to operate on that subject would be announced
all together rather than just the label for the subject.

Source of change request:
https://github.com/hmrc/design-patterns/issues/31#issuecomment-799628620